### PR TITLE
fix: correct typo in API URL constant

### DIFF
--- a/spec/audio_spec.cr
+++ b/spec/audio_spec.cr
@@ -7,7 +7,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       parts = ["file", "model", "response_format"]
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/audio/transcriptions")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/audio/transcriptions")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             HTTP::FormData.parse(req) do |part|
@@ -26,7 +26,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       parts = ["file", "model", "response_format"]
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/audio/translations")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/audio/translations")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             HTTP::FormData.parse(req) do |part|

--- a/spec/chat_spec.cr
+++ b/spec/chat_spec.cr
@@ -26,7 +26,7 @@ module OpenAI
     it "should return valid chat completion response" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: CHAT_COMPLETION_RES)
 
@@ -40,7 +40,7 @@ module OpenAI
     it "test chat completion functions" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             cr = ChatCompletionRequest.from_json(req.body.try &.gets_to_end || "")
@@ -62,7 +62,7 @@ module OpenAI
     it "test chat completion function with test struct" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             cr = ChatCompletionRequest.from_json(req.body.try &.gets_to_end || "")
@@ -119,7 +119,7 @@ module OpenAI
           ),
         ]
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -156,7 +156,7 @@ module OpenAI
       it "test chat completion streaming error without data prefix" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -181,7 +181,7 @@ module OpenAI
       it "test chat completion streaming error with data prefix" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -211,7 +211,7 @@ module OpenAI
       it "test chat completion streaming rate limit error" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/chat/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/chat/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})

--- a/spec/completion_spec.cr
+++ b/spec/completion_spec.cr
@@ -24,7 +24,7 @@ module OpenAI
     it "should return valid completion response" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: COMPLETION_RES)
 
@@ -59,7 +59,7 @@ module OpenAI
           ),
         ]
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -94,7 +94,7 @@ module OpenAI
       it "test completion streaming error without data prefix" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -119,7 +119,7 @@ module OpenAI
       it "test chat completion streaming error with data prefix" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -149,7 +149,7 @@ module OpenAI
       it "test completion streaming rate limit error" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})
@@ -172,7 +172,7 @@ module OpenAI
       it "test completion streaming broken json" do
         client = Client.new(TEST_SECRET)
         WebMock.wrap do
-          WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/completions")
+          WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/completions")
             .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
             .to_return do |req|
               headers = HTTP::Headers.new.merge!({"Content-Type" => "text/event-stream"})

--- a/spec/embeddings_spec.cr
+++ b/spec/embeddings_spec.cr
@@ -43,7 +43,7 @@ module OpenAI
     it "test embeddings endpoint with float embeddings" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/embeddings")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/embeddings")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: EMBEDDING_RES)
 
@@ -57,7 +57,7 @@ module OpenAI
     it "test embeddings endpoint with base64 embeddings" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/embeddings")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/embeddings")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: EMBEDDING_RES_B64)
 

--- a/spec/file_spec.cr
+++ b/spec/file_spec.cr
@@ -7,7 +7,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       parts = ["file", "purpose"]
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/files")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/files")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             HTTP::FormData.parse(req) do |part|
@@ -25,7 +25,7 @@ module OpenAI
     it "test delete file" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:delete, "#{OPENAI_API_DEFUALT_URL}/files/file-abc123")
+        WebMock.stub(:delete, "#{OPENAI_API_DEFAULT_URL}/files/file-abc123")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FILE_DEL_RES)
 
@@ -37,7 +37,7 @@ module OpenAI
     it "test list files" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/files")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/files")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FILE_LIST_RES)
 
@@ -50,7 +50,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       body = File.read(AUDIO_SAMPLE)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/files/file-abc123/content")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/files/file-abc123/content")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: body)
 

--- a/spec/fine_tuning_spec.cr
+++ b/spec/fine_tuning_spec.cr
@@ -6,7 +6,7 @@ module OpenAI
     it "test create fine-tuning job" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/fine_tuning/jobs")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/fine_tuning/jobs")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FINE_TUNING_JOB)
 
@@ -19,7 +19,7 @@ module OpenAI
     it "test list fine-tuning jobs" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/fine_tuning/jobs?limit=20")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/fine_tuning/jobs?limit=20")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FINE_TUNING_JOB_LIST)
 
@@ -31,7 +31,7 @@ module OpenAI
     it "test retrieve fine-tuning job" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FINE_TUNING_JOB_RET)
 
@@ -44,7 +44,7 @@ module OpenAI
     it "test cancel fine-tuning job" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FINE_TUNING_JOB)
 
@@ -57,7 +57,7 @@ module OpenAI
     it "test list fine-tuning events" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events?limit=20&after=5")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events?limit=20&after=5")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: FINE_TUNING_EVENTS_LIST)
 

--- a/spec/image_spec.cr
+++ b/spec/image_spec.cr
@@ -6,7 +6,7 @@ module OpenAI
     it "test create image" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/images/generations")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/images/generations")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: IMAGE_RES)
 
@@ -20,7 +20,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       parts = ["image", "mask", "prompt", "n", "size", "response_format"]
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/images/edits")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/images/edits")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             HTTP::FormData.parse(req) do |part|
@@ -40,7 +40,7 @@ module OpenAI
       client = Client.new(TEST_SECRET)
       parts = ["image", "n", "size", "response_format"]
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/images/variations")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/images/variations")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return do |req|
             HTTP::FormData.parse(req) do |part|

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -6,7 +6,7 @@ module OpenAI
     it "Returns a list of models" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/models")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/models")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: MODELS_SAMPLE)
 
@@ -17,7 +17,7 @@ module OpenAI
     it "Returns a model by particular id" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/models/davinci")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/models/davinci")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: MODEL_SAMPLE)
 
@@ -54,7 +54,7 @@ module OpenAI
     it "Returns a list of engines" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/engines")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/engines")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: ENGINES_SAMPLE)
 
@@ -65,7 +65,7 @@ module OpenAI
     it "Returns a engine by particular id" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:get, "#{OPENAI_API_DEFUALT_URL}/engines/davinci")
+        WebMock.stub(:get, "#{OPENAI_API_DEFAULT_URL}/engines/davinci")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: ENGINE_SAMPLE)
 

--- a/spec/moderation_spec.cr
+++ b/spec/moderation_spec.cr
@@ -6,7 +6,7 @@ module OpenAI
     it "create moderation" do
       client = Client.new(TEST_SECRET)
       WebMock.wrap do
-        WebMock.stub(:post, "#{OPENAI_API_DEFUALT_URL}/moderations")
+        WebMock.stub(:post, "#{OPENAI_API_DEFAULT_URL}/moderations")
           .with(headers: {"Authorization" => "Bearer #{TEST_SECRET}"})
           .to_return(body: MODERATION_RES)
 

--- a/src/openai/config.cr
+++ b/src/openai/config.cr
@@ -48,7 +48,7 @@ module OpenAI
 
       def self.default(api_key : String? = nil, proxy = nil)
         key = api_key || OpenAI.default_apikey
-        new(key, API_BASE || OPENAI_API_DEFUALT_URL, ORGANIZATION, :open_ai, proxy: proxy)
+        new(key, API_BASE || OPENAI_API_DEFAULT_URL, ORGANIZATION, :open_ai, proxy: proxy)
       end
 
       def self.azure(api_key : String?, api_base : String?, api_type : ApiType = :azure, model_mapper : Proc(String, String)? = nil, proxy = nil)

--- a/src/openai/constants.cr
+++ b/src/openai/constants.cr
@@ -5,7 +5,7 @@ module OpenAI
   API_KEY                = ENV["OPENAI_API_KEY"]?
   API_KEY_PATH           = ENV["OPENAI_API_KEY_PATH"]?
   ORGANIZATION           = ENV["OPENAI_ORGANIZATION"]? || ""
-  OPENAI_API_DEFUALT_URL = "https://api.openai.com/v1"
+  OPENAI_API_DEFAULT_URL = "https://api.openai.com/v1"
   API_BASE               = ENV["OPENAI_API_BASE"]?
   API_TYPE               = ApiType.parse(ENV["OPENAI_API_TYPE"]? || "open_ai")
   API_VERSION            = ENV["OPENAI_API_VERSION"]? || begin


### PR DESCRIPTION
Hello @stakach and crystal-openai developers.

This is probably a typo.
However, if it is intentional, feel free to close it.