### PR TITLE
fix: correct typo 'Uknown' to 'Unknown'

### DIFF
--- a/src/openai/api/embeddings.cr
+++ b/src/openai/api/embeddings.cr
@@ -69,7 +69,7 @@ module OpenAI
 
   # Enumerates the models which can be used to generate Embedding vectors.
   enum EmbeddingModel
-    Uknown
+    Unknown
 
     # Deprecated: Will be shut down on January 04, 2024. Use `AdaEmbeddingV2` instead
     AdaSimilarity
@@ -114,7 +114,7 @@ module OpenAI
     end
 
     def to_s
-      raise OpenAIError.new("Unkonwn embedding model received. #{self}") if self == Uknown
+      raise OpenAIError.new("Unkonwn embedding model received. #{self}") if self == Unknown
       OpenAI.em_2_text[self]
     end
   end

--- a/src/openai/client.cr
+++ b/src/openai/client.cr
@@ -361,7 +361,7 @@ module OpenAI
       if res = res_err.error
         raise APIError.new(resp.status_code, res)
       else
-        raise OpenAIError.new("Uknown error received from server")
+        raise OpenAIError.new("Unknown error received from server")
       end
     end
   end


### PR DESCRIPTION
There was another place that seemed to be a typo.
Thank you.